### PR TITLE
Fix Windows path resolving

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,5 @@
 import { dirname } from 'path'
+import { URL } from 'url'
 import { workspace, window, languages, ExtensionContext, TextDocument, TextEdit, Uri, commands, Range, Position } from 'vscode'
 
 import { log } from './log'
@@ -69,7 +70,8 @@ export function activate(context: ExtensionContext) {
 }
 
 function getCwd(filepath: string): string {
-	const workspacePath = workspace.getWorkspaceFolder(Uri.parse(filepath))?.uri.path
+	const pathToUse = process.platform === 'win32' ? new URL(`file://${filepath}`).href : filepath
+	const workspacePath = workspace.getWorkspaceFolder(Uri.parse(pathToUse))?.uri.fsPath
 
 	if (!workspacePath) {
 		const dir = dirname(filepath)

--- a/src/run-command.ts
+++ b/src/run-command.ts
@@ -31,7 +31,7 @@ export async function runCommand(text: string, command: string, filename: string
 		log(`Skipping ${filename}`)
 		return text
 	} catch (e) {
-		errorOut(`${e.shortMessage}\n${stripColor(e.stderr)}`)
+		errorOut(`${(e as any).shortMessage}\n${stripColor((e as any).stderr)}`)
 		return text
 	}
 }


### PR DESCRIPTION
- Use WHATWG URL implementation for Windows path.
- Change `.path` to `.fspath` from uri

Fixes #11

Sorry for the added `as any`, but TSC wouldn't compile since the error was of type `unknown`.
Let me know if you wish for a change! :)